### PR TITLE
Fix a error with empty \Contao\PageModel

### DIFF
--- a/contao/classes/ImiMMChangeLanguageObserver.php
+++ b/contao/classes/ImiMMChangeLanguageObserver.php
@@ -177,7 +177,13 @@ class ImiMMChangeLanguageObserver
                         // the item is not published in this language
                         // fallback to the parent page
                         $targetPage = $event->getNavigationItem()->getTargetPage();
-                        $targetPage = \Contao\PageModel::findByPk($targetPage->pid);
+                        // If the pid is 0 we allready have the root page.
+                        if(!empty($targetPage->pid)){
+                            $targetPage = \Contao\PageModel::findByPk($targetPage->pid);
+                        } else {
+                            $targetPage = \Contao\PageModel::findByPk($targetPage->id);
+                        }
+
                         $event->getNavigationItem()->setTargetPage($targetPage, false);
                         return;
                     }

--- a/contao/classes/ImiMMChangeLanguageObserver.php
+++ b/contao/classes/ImiMMChangeLanguageObserver.php
@@ -121,12 +121,18 @@ class ImiMMChangeLanguageObserver
 
         $currentMetaModels = $this->getCurrentMetamodels();
 
+        if (!$currentMetaModels) {
+            return;
+        }
+
 		$alias = \Input::get('auto_item');
 		if ($alias == null) {
 			return;
 		}
 
 		if ($targetLanguage == $GLOBALS['TL_LANGUAGE']) {
+            // add missing url parameter
+		    $event->getUrlParameterBag()->setUrlAttribute('items', $alias);
 			return;
 		}
 

--- a/contao/classes/ImiMMChangeLanguageObserver.php
+++ b/contao/classes/ImiMMChangeLanguageObserver.php
@@ -133,7 +133,7 @@ class ImiMMChangeLanguageObserver
 		if ($targetLanguage == $GLOBALS['TL_LANGUAGE']) {
             // add missing url parameter
 		    $event->getUrlParameterBag()->setUrlAttribute('items', $alias);
-			return;
+		    return;
 		}
 
 		// allow overwriting of the auto-detected definition
@@ -160,6 +160,29 @@ class ImiMMChangeLanguageObserver
 			if (count($ids) < 1) {
 				continue;
 			}
+
+            // check for a published attribute
+			if ($metaModel->hasAttribute('published')) {
+                $published = $metaModel->getAttribute('published');
+
+                $publishedData = array_shift($published->getTranslatedDataFor($ids, $targetLanguage));
+                if ($publishedData == null) {
+                    $publishedData = array_shift($published->getTranslatedDataFor($ids, $strFallbackLanguage));
+                }
+
+                if (!is_null($publishedData)) {
+                    // found a published attribute
+
+                    if (!$publishedData['value']) {
+                        // the item is not published in this language
+                        // fallback to the parent page
+                        $targetPage = $event->getNavigationItem()->getTargetPage();
+                        $targetPage = \Contao\PageModel::findByPk($targetPage->pid);
+                        $event->getNavigationItem()->setTargetPage($targetPage, false);
+                        return;
+                    }
+                }
+            }
 
 			$attributeData = array_shift($attribute->getTranslatedDataFor($ids, $targetLanguage));
 			if ($attributeData == null) {


### PR DESCRIPTION
Fix a problem for the target page where the mm items wasn't published, and the target page was the root page of the language. Which ends in a fatal error.